### PR TITLE
Command-line tools

### DIFF
--- a/lib/regressed/cli/base.rb
+++ b/lib/regressed/cli/base.rb
@@ -1,13 +1,45 @@
+require 'optparse'
+require 'regressed/prediction'
+require 'regressed/prediction/rspec'
+
 module Regressed
   module CLI
     class Base
       def run(args = ARGV)
-        puts 'Hello world!'
+
+        options = {}
+        OptionParser.new do |opts|
+          opts.on '--collect' do
+            options[:collect] = true
+          end
+        end.parse!
+
+        if options[:collect]
+          collect
+        else
+          run_changed
+        end
+
         0
       rescue StandardError, SyntaxError => e
         $stderr.puts e.message
         $stderr.puts e.backtrace
         return 1
+      end
+
+      private
+
+      def collect
+        env = { 'REGRESSED_COLLECT' => '1' }
+        system env, collect_command
+      end
+
+      def run_changed
+        coverage = Regressed::Prediction::RSpec.load_json_dump '.regressed-rspec.json',
+                                                               Rugged::Repository.new('.')
+        parameters = coverage.entries.map(&:command_line_parameter).join(' ')
+
+        system "#{coverage.command} #{parameters}"
       end
     end
   end

--- a/lib/regressed/cli/minitest.rb
+++ b/lib/regressed/cli/minitest.rb
@@ -1,6 +1,11 @@
 module Regressed
   module CLI
     class Minitest < Base
+      private
+
+      def collect_command
+        'rake test'
+      end
     end
   end
 end

--- a/lib/regressed/cli/rspec.rb
+++ b/lib/regressed/cli/rspec.rb
@@ -1,6 +1,11 @@
 module Regressed
   module CLI
     class RSpec < Base
+      private
+
+      def collect_command
+        'rspec'
+      end
     end
   end
 end

--- a/lib/regressed/minitest.rb
+++ b/lib/regressed/minitest.rb
@@ -2,7 +2,7 @@ require 'regressed'
 require 'regressed/collection'
 require 'regressed/collection/minitest'
 
-if ENV['COLLECTION']
+if ENV['REGRESSED_COLLECT']
   repo = Rugged::Repository.new('.')
   Regressed::Collection::Minitest.new(repo)
 end

--- a/lib/regressed/prediction/base.rb
+++ b/lib/regressed/prediction/base.rb
@@ -50,13 +50,13 @@ module Regressed
         infos.map(&entry_class.method(:new))
       end
 
-      private
-
-      attr_reader :raw_data, :repo
-
       def oid
         raw_data['oid']
       end
+
+      private
+
+      attr_reader :raw_data, :repo
 
       def cov_map
         @cov_map ||= Hash.new do |cov_map, path|

--- a/lib/regressed/prediction/base.rb
+++ b/lib/regressed/prediction/base.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Regressed
   module Prediction
     class Base
@@ -8,9 +10,13 @@ module Regressed
           @info = info
         end
 
-        def cmd
+        def command_line_parameter
           raise NotImplementedError
         end
+      end
+
+      def command
+        fail NotImplementedError
       end
 
       def initialize(raw_data, repo)

--- a/lib/regressed/prediction/minitest.rb
+++ b/lib/regressed/prediction/minitest.rb
@@ -2,9 +2,13 @@ module Regressed
   module Prediction
     class Minitest < Base
       class Entry < Base::Entry
-        def cmd
-          "rake test #{info['file']}"
+        def command_line_parameter
+          info['file']
         end
+      end
+
+      def command
+        'rake test'
       end
 
       def entry_class

--- a/lib/regressed/prediction/rspec.rb
+++ b/lib/regressed/prediction/rspec.rb
@@ -2,8 +2,8 @@ module Regressed
   module Prediction
     class RSpec < Base
       class Entry < Base::Entry
-        def cmd
-          "rspec #{info['spec']}:#{info['line']}"
+        def command_line_parameter
+          "#{info['spec']}:#{info['line']}"
         end
 
         def full
@@ -13,6 +13,10 @@ module Regressed
 
       def entry_class
         RSpec::Entry
+      end
+
+      def command
+        'rspec'
       end
     end
   end

--- a/lib/regressed/rspec.rb
+++ b/lib/regressed/rspec.rb
@@ -2,7 +2,7 @@ require 'regressed'
 require 'regressed/collection'
 require 'regressed/collection/rspec'
 
-if ENV['COLLECTION']
+if ENV['REGRESSED_COLLECT']
   repo = Rugged::Repository.new('.')
   Regressed::Collection::RSpec.new(repo)
 end

--- a/spec/regressed/cli_spec.rb
+++ b/spec/regressed/cli_spec.rb
@@ -53,9 +53,16 @@ describe 'CLI' do
       end
 
       context 'after changing git head' do
-        pending 'change head ref, i.e. by commiting'
+        before do
+          write_file 'commit_me', 'test'
+          commit_file 'commit_me'
+        end
+
         describe 'when ran again without --collect' do
-          it 'fails'
+          it 'fails' do
+            exit_status = execute "bundle exec #{command} 2> /dev/null"
+            expect(exit_status).to be false
+          end
         end
       end
     end

--- a/spec/regressed/cli_spec.rb
+++ b/spec/regressed/cli_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe 'CLI' do
+  include_context 'test repository'
+
+  after(:example) do
+    # other tests use coverage files persisting between examples
+    remove_coverage_files
+  end
+
+  let(:coverage_file_path) do
+    File.join(repo.workdir, coverage_filename)
+  end
+
+  shared_examples 'foo baz project' do
+    context 'when first ran with --collect' do
+      before do
+        exit_status = execute "bundle exec #{command} --collect > /dev/null"
+        expect(exit_status).to be true
+      end
+
+      it 'creates coverage file' do
+        expect(JSON.parse(File.read(coverage_file_path))).to be_truthy
+      end
+
+      describe 'when ran again' do
+        let(:content) do
+          execute_capturing_output "bundle exec #{command}"
+        end
+
+        it 'does nothing' do
+          expect(content).to include('0 examples, 0 failures')
+        end
+      end
+
+      describe 'when ran with --tests' do
+        it 'displays empty result'
+      end
+
+      describe 'when appending a line to bar' do
+        before do
+          insert_line 'lib/whatever.rb', 8, '    fail' # append to method `bar`
+        end
+
+        it 'runs tests for bars and bars_again' do
+          content = execute_capturing_output "bundle exec #{command}"
+          expect(content).to include('2 examples, 2 failures')
+        end
+
+        describe 'when ran with --tests' do
+          it 'displays list of 2 tests: bars and bars_again'
+        end
+      end
+
+      context 'after changing git head' do
+        pending 'change head ref, i.e. by commiting'
+        describe 'when ran again without --collect' do
+          it 'fails'
+        end
+      end
+    end
+
+    context 'when ran for the first time without --collect' do
+      it 'fails' do
+        exit_status = execute "bundle exec #{command} > /dev/null"
+        expect(exit_status).to be false
+      end
+    end
+  end
+
+  describe 'with RSpec' do
+    let(:coverage_filename) { '.regressed-rspec.json' }
+    let(:command) { 'regressed-rspec' }
+
+    include_examples 'foo baz project'
+  end
+
+  pending 'with Minitest' do
+    let(:coverage_filename) { '.regressed-minitest.json' }
+    let(:command) { 'regressed-minitest' }
+
+    include_examples 'foo baz project'
+  end
+end

--- a/spec/regressed/cli_spec.rb
+++ b/spec/regressed/cli_spec.rb
@@ -36,9 +36,9 @@ describe 'CLI' do
         end
       end
 
-      pending 'when ran with --tests' do
+      describe 'when ran with --tests' do
         let!(:content) do
-          execute_capturing_output "bundle exec #{command} --tests"
+          execute_capturing_output "bundle exec #{command} --tests 2> /dev/null"
         end
 
         it 'displays empty result' do
@@ -61,7 +61,13 @@ describe 'CLI' do
           end
 
           describe 'with --tests' do
-            it 'displays list of 2 tests: bars and bars_again'
+            let(:content) do
+              execute_capturing_output "bundle exec #{command} --tests"
+            end
+
+            it 'outputs some test file name' do
+              expect(content).to match(/whatever_.*\.rb/)
+            end
           end
 
           describe 'with --collect' do
@@ -78,7 +84,7 @@ describe 'CLI' do
                 execute "bundle exec #{command} > /dev/null"
               end
 
-              it 'exits with 0' do
+              it 'exits with status 0' do
                 expect(exit_status_3).to be true
               end
             end

--- a/spec/regressed/cli_spec.rb
+++ b/spec/regressed/cli_spec.rb
@@ -29,7 +29,7 @@ describe 'CLI' do
         end
 
         it 'does nothing' do
-          expect(content).to include('0 examples, 0 failures')
+          expect(content).not_to include('examples')
         end
       end
 
@@ -69,7 +69,7 @@ describe 'CLI' do
 
     context 'when ran for the first time without --collect' do
       it 'fails' do
-        exit_status = execute "bundle exec #{command} > /dev/null"
+        exit_status = execute "bundle exec #{command} 2> /dev/null"
         expect(exit_status).to be false
       end
     end

--- a/spec/regressed/integration_spec.rb
+++ b/spec/regressed/integration_spec.rb
@@ -1,21 +1,7 @@
 require 'spec_helper'
 
 describe 'Integration with test frameworks' do
-  before(:all) do
-    clear_tmp_dir!
-    create_repo 'whatever'
-    write_fixture_subdir 'whatever', '.'
-    execute 'bundle install > /dev/null'
-    commit_file 'Gemfile.lock'
-  end
-
-  after(:example) do
-    undo_changes!
-  end
-
-  after(:all) do
-    destroy_repo 'whatever'
-  end
+  include_context 'test repository'
 
   shared_examples 'foo baz project' do
     describe 'when nothing is changed' do
@@ -108,7 +94,7 @@ describe 'Integration with test frameworks' do
 
   describe 'with RSpec' do
     before(:all) do
-      execute 'bundle exec rspec > /dev/null', 'COLLECTION' => '1'
+      execute 'bundle exec rspec > /dev/null', 'REGRESSED_COLLECT' => '1'
     end
 
     let(:prediction) do
@@ -134,7 +120,7 @@ describe 'Integration with test frameworks' do
 
   describe 'with Minitest' do
     before(:all) do
-      execute 'ruby -I lib spec/whatever_test.rb > /dev/null', 'COLLECTION' => '1'
+      execute 'ruby -I lib spec/whatever_test.rb > /dev/null', 'REGRESSED_COLLECT' => '1'
     end
 
     let(:prediction) do

--- a/spec/regressed/prediction/minitest_spec.rb
+++ b/spec/regressed/prediction/minitest_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Regressed::Prediction::Minitest do
   describe Regressed::Prediction::Minitest::Entry do
-    describe '#cmd method' do
+    describe '#command_line_parameter method' do
       let(:entry) {
         described_class.new 'file' => './spec/lol_test.rb', 'line' => 123
       }
 
-      it "returns something runnable" do
-        expect(entry.cmd).to eq('rake test ./spec/lol_test.rb')
+      it 'returns command-line parameter for particular test' do
+        expect(entry.command_line_parameter).to eq('./spec/lol_test.rb')
       end
     end
   end

--- a/spec/regressed/prediction/rspec_spec.rb
+++ b/spec/regressed/prediction/rspec_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe Regressed::Prediction::RSpec do
   describe Regressed::Prediction::RSpec::Entry do
-    describe '#cmd method' do
+    describe '#command_line_parameter method' do
       let(:entry) {
         described_class.new 'spec' => './spec/lol_spec.rb', 'line' => 123
       }
 
-      it "returns something runnable" do
-        expect(entry.cmd).to eq('rspec ./spec/lol_spec.rb:123')
+      it 'returns command-line parameter for particular test' do
+        expect(entry.command_line_parameter).to eq('./spec/lol_spec.rb:123')
       end
     end
   end

--- a/spec/support/temp_repo.rb
+++ b/spec/support/temp_repo.rb
@@ -153,7 +153,8 @@ module TempRepo
 
   def execute_capturing_output(cmd, env={})
     Tempfile.create("output") do |f|
-      execute "#{cmd} > #{f.path}"
+      exit_status = execute "#{cmd} > #{f.path}"
+      fail "Command #{cmd} exited: #{$?}" unless exit_status
       f.read
     end
   end

--- a/spec/support/temp_repo.rb
+++ b/spec/support/temp_repo.rb
@@ -154,7 +154,7 @@ module TempRepo
   def execute_capturing_output(cmd, env={})
     Tempfile.create("output") do |f|
       exit_status = execute "#{cmd} > #{f.path}"
-      fail "Command #{cmd} exited: #{$?}" unless exit_status
+      fail "Command #{cmd} exited with code #{$?.exitstatus}" unless exit_status
       f.read
     end
   end


### PR DESCRIPTION
- [x] `--collect` gathers coverage data
- [x] by default runs tests affected by changed lines
- [x] correct error message when no coverage json file
- [x] check why it runs 3 tests after initial `--collect` and after no changes
- [x] prevent running if git `HEAD` differs from `HEAD` of coverage data
- [ ] support for minitest
- [x] `--tests` shows what tests are affected by changes instead of running them
- [ ] sane code in `Regressed::CLI::Base`
- [ ] handle invalid command line (i.e. `--collect --tests`)
